### PR TITLE
Update README.md with new backend CA cert location

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ FROM docker.iterative.ai/viewer_backend:latest
 USER root
 COPY scm_provider_root_ca.crt /usr/local/share/ca-certificates/ca.crt
 RUN cat /usr/local/share/ca-certificates/ca.crt >> /usr/local/lib/python3.10/site-packages/certifi/cacert.pem && \
-    cp /usr/local/lib/python3.10/site-packages/certifi/cacert.pem /usr/lib/ssl/cert.pem
+    cp /usr/local/lib/python3.10/site-packages/certifi/cacert.pem /usr/lib/ssl/cert.pem && \
+    update-ca-certificates
 USER dvc
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ FROM docker.iterative.ai/viewer_backend:latest
 USER root
 COPY scm_provider_root_ca.crt /usr/local/share/ca-certificates/ca.crt
 RUN cat /usr/local/share/ca-certificates/ca.crt >> /usr/local/lib/python3.10/site-packages/certifi/cacert.pem && \
-    update-ca-certificates
+    cp /usr/local/lib/python3.10/site-packages/certifi/cacert.pem /usr/lib/ssl/cert.pem
 USER dvc
 ```
 


### PR DESCRIPTION
The previous version were not working `aiohttp` library. It is using `ssl` library which under `/usr/lib/ssl/cert.pem` seeks for the CA certificate.

```python

>>> import ssl
>>> print(ssl.get_default_verify_paths())
DefaultVerifyPaths(cafile='/usr/lib/ssl/cert.pem', capath='/usr/lib/ssl/certs', openssl_cafile_env='SSL_CERT_FILE', openssl_cafile='/usr/lib/ssl/cert.pem', openssl_capath_env='SSL_CERT_DIR', openssl_capath='/usr/lib/ssl/certs')
```

`update-ca-certificates` is optional here - will help work with `curl` or other os commands. 

Found working on https://github.com/iterative/helm-charts/issues/5