### PR TITLE
Fix ID of packer build step and add custom ami name when we are skipping AMI creation

### DIFF
--- a/.github/workflows/build-ami.yml
+++ b/.github/workflows/build-ami.yml
@@ -44,7 +44,7 @@ jobs:
         run: "packer validate ./studio-selfhosted.pkr.hcl"
 
       - name: Run `packer build`
-        id: validate
+        id: build
         run: "packer build ./studio-selfhosted.pkr.hcl"
         env:
           PKR_VAR_skip_create_ami: ${{ github.event_name != 'pull_request' && 'false' || 'true' }}

--- a/packer/studio-selfhosted.pkr.hcl
+++ b/packer/studio-selfhosted.pkr.hcl
@@ -74,7 +74,7 @@ data "amazon-ami" "ubuntu" {
 
 source "amazon-ebs" "source" {
   ami_groups      = ["all"]
-  ami_name        = var.image_name
+  ami_name        = var.skip_create_ami ? "studio-selfhosted {{isotime `2006-01-02_15-04-05`}}" : var.image_name
   ami_description = var.image_description
   ami_regions     = local.aws_release_regions
   skip_create_ami = var.skip_create_ami


### PR DESCRIPTION
Fixes:
> [Invalid workflow file: .github/workflows/build-ami.yml#L47](https://github.com/iterative/studio-selfhosted/actions/runs/4322097960/workflow)
> The workflow is not valid. .github/workflows/build-ami.yml (Line: 47, Col: 13): The identifier 'validate' may not be used more than once within the same scope.