### PR TITLE
Remove the Helm chart's default values.yaml in AMI

### DIFF
--- a/packer/setup_ubuntu.sh
+++ b/packer/setup_ubuntu.sh
@@ -6,9 +6,3 @@ set -o pipefail
 
 # Add Helm Iterative Repository
 helm repo add iterative https://helm.iterative.ai
-
-# Add Helm default values from latest release
-helm pull iterative/studio
-tar -zxvf studio-*.tgz -C /tmp
-mv /tmp/studio/values.yaml ~/studio-values.yaml
-rm studio-*.tgz


### PR DESCRIPTION
We should not include the Helm chart's default `values.yaml` in the AMI. 

We've experienced that some users will take the default `values.yaml` and use it as their main configuration file. This means that when we change default values in the Helm chart, it will have no effect as the users would have overridden them by their configuration.