### PR TITLE
Add kubelet args and save install scripts

### DIFF
--- a/packer/setup_root.sh
+++ b/packer/setup_root.sh
@@ -1,8 +1,13 @@
-#/bin/bash
+#!/bin/bash
 
 PS4='studio-selfhosted:setup_root.sh: '
 set -eux
 set -o pipefail
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -59,7 +64,7 @@ metadata:
 YAML
 
 # Install Helm - script uploaded with packer
-bash /tmp/helm3.sh
+bash /home/ubuntu/.studio_install/helm3.sh
 
 # Add Helm Iterative Repository
 helm repo add iterative https://helm.iterative.ai

--- a/packer/setup_root.sh
+++ b/packer/setup_root.sh
@@ -13,7 +13,17 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Install K3s - script uploaded with packer
 K3S_VERSION=v1.25.7+k3s1
-INSTALL_K3S_SKIP_START="true" INSTALL_K3S_EXEC="--disable=traefik"  K3S_KUBECONFIG_MODE="644" INSTALL_K3S_VERSION=${K3S_VERSION} sh /tmp/k3s.sh -
+K3S_KUBECONFIG_MODE="644"
+INSTALL_K3S_VERSION=${K3S_VERSION}
+INSTALL_K3S_SKIP_START="true"
+
+INSTALL_K3S_EXEC=""
+INSTALL_K3S_EXEC="$INSTALL_K3S_EXEC --disable=traefik"
+INSTALL_K3S_EXEC="$INSTALL_K3S_EXEC --kube-reserved cpu=500m,memory=1Gi,ephemeral-storage=1Gi"
+INSTALL_K3S_EXEC="$INSTALL_K3S_EXEC --system-reserved cpu=500m,memory=1Gi,ephemeral-storage=1Gi"
+INSTALL_K3S_EXEC="$INSTALL_K3S_EXEC --eviction-hard memory.available<0.5Gi,nodefs.available<10%"
+
+sh /home/ubuntu/.studio_install/k3s.sh -
 echo KUBECONFIG="/etc/rancher/k3s/k3s.yaml" >> /etc/environment
 
 # Install k9s

--- a/packer/setup_ubuntu.sh
+++ b/packer/setup_ubuntu.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 PS4='studio-selfhosted:setup_ubuntu.sh: '
 set -eux

--- a/packer/studio-selfhosted.pkr.hcl
+++ b/packer/studio-selfhosted.pkr.hcl
@@ -102,14 +102,32 @@ source "amazon-ebs" "source" {
 build {
   sources = ["source.amazon-ebs.source"]
 
+  # Install script running as 'root'
+  provisioner "shell" {
+    inline = [
+      "mkdir /home/ubuntu/.studio_install",
+    ]
+  }
+
+
   provisioner "file" {
     source      = "k3s.sh"
-    destination = "/tmp/k3s.sh"
+    destination = "/home/ubuntu/.studio_install/k3s.sh"
   }
 
   provisioner "file" {
     source      = "helm3.sh"
-    destination = "/tmp/helm3.sh"
+    destination = "/home/ubuntu/.studio_install/helm3.sh"
+  }
+
+  provisioner "file" {
+    source      = "setup_root.sh"
+    destination = "/home/ubuntu/.studio_install/setup_root.sh"
+  }
+
+  provisioner "file" {
+    source      = "setup_ubuntu.sh"
+    destination = "/home/ubuntu/.studio_install/setup_ubuntu.sh"
   }
 
   provisioner "shell" {
@@ -118,12 +136,11 @@ build {
 
   # Install script running as 'root'
   provisioner "shell" {
-    script          = "${path.root}/setup_root.sh"
-    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo bash {{ .Path }}"
+    inline = ["sudo bash /home/ubuntu/.studio_install/setup_root.sh"]
   }
 
   # Install script running as 'ubuntu'
   provisioner "shell" {
-    script = "${path.root}/setup_ubuntu.sh"
+    inline = ["bash /home/ubuntu/.studio_install/setup_ubuntu.sh"]
   }
 }


### PR DESCRIPTION
Two things:

- [x] Add Kubelet args for resource limits
- x] Store Install script in a hidden directory
       We figured out that when we want to fix something on the instance, scripts like helm or k3s are missing, and for support, we need to create them again.