### PR TITLE
Rename export-studio-logs to create-support-bundle

### DIFF
--- a/packer/create-support-bundle.sh
+++ b/packer/create-support-bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-LOG_DIR=/tmp/studio-logs
+LOG_DIR=/tmp/studio-support
 mkdir "$LOG_DIR"
 
 get_logs() {
@@ -14,5 +14,5 @@ get_logs beat > "$LOG_DIR/beat.txt"
 get_logs ui > "$LOG_DIR/ui.txt"
 get_logs worker > "$LOG_DIR/worker.txt"
 
-tar -zcvf /tmp/studio-logs.tar.gz "$LOG_DIR"
+tar -zcvf /tmp/studio-support.tar.gz "$LOG_DIR"
 rm -rf "$LOG_DIR"

--- a/packer/setup_root.sh
+++ b/packer/setup_root.sh
@@ -81,6 +81,6 @@ bash /home/ubuntu/.studio_install/helm3.sh
 # Add Helm Iterative Repository
 helm repo add iterative https://helm.iterative.ai
 
-# Move the log exporter script
-cp /home/ubuntu/.studio_install/export-studio-logs /usr/local/bin/export-studio-logs
-chmod +x /usr/local/bin/export-studio-logs
+# Move the support bundle script
+cp /home/ubuntu/.studio_install/create-support-bundle /usr/local/bin/create-support-bundle
+chmod +x /usr/local/bin/create-support-bundle

--- a/packer/setup_root.sh
+++ b/packer/setup_root.sh
@@ -81,6 +81,6 @@ bash /home/ubuntu/.studio_install/helm3.sh
 # Add Helm Iterative Repository
 helm repo add iterative https://helm.iterative.ai
 
-# Move the support bundle script
+# Copy the support bundle script
 cp /home/ubuntu/.studio_install/create-support-bundle /usr/local/bin/create-support-bundle
 chmod +x /usr/local/bin/create-support-bundle

--- a/packer/studio-selfhosted.pkr.hcl
+++ b/packer/studio-selfhosted.pkr.hcl
@@ -120,8 +120,8 @@ build {
   }
 
   provisioner "file" {
-    source      = "export-studio-logs.sh"
-    destination = "/home/ubuntu/.studio_install/export-studio-logs"
+    source      = "create-support-bundle.sh"
+    destination = "/home/ubuntu/.studio_install/create-support-bundle"
   }
 
   provisioner "file" {


### PR DESCRIPTION
- Rename export-studio-logs to create-support-bundle

"Support bundle" is a more common terminology for archives containing troubleshooting information.