### PR TITLE
Make namespace configurable in support bundle script

### DIFF
--- a/packer/create-support-bundle.sh
+++ b/packer/create-support-bundle.sh
@@ -15,7 +15,7 @@ while [ $# -ne 0 ]; do
   case $1 in
     --namespace)
       shift 1
-      export NAMESPACE=$1
+      NAMESPACE=$1
       shift 1
       ;;
     -h|--help)

--- a/packer/create-support-bundle.sh
+++ b/packer/create-support-bundle.sh
@@ -1,12 +1,39 @@
 #!/bin/bash
 set -euxo pipefail
 
+NAMESPACE=studio
 LOG_DIR=/tmp/studio-support
+
+usage () {
+  echo "Usage: $0 [OPTIONS]"
+  echo
+  echo "OPTIONS:"
+  echo "  --namespace <namespace>"
+}
+
+while [ $# -ne 0 ]; do
+  case $1 in
+    --namespace)
+      shift 1
+      export NAMESPACE=$1
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 0
+      ;;
+  esac
+done
+
 mkdir "$LOG_DIR"
 
 get_logs() {
-    POD_NAME=$(kubectl get pods --namespace studio -l "app.kubernetes.io/name=studio-$1,app.kubernetes.io/instance=studio" -o jsonpath="{.items[0].metadata.name}")
-    kubectl logs $POD_NAME -n studio
+    POD_NAME=$(kubectl get pods --namespace $NAMESPACE -l "app.kubernetes.io/name=studio-$1,app.kubernetes.io/instance=studio" -o jsonpath="{.items[0].metadata.name}")
+    kubectl logs $POD_NAME --namespace $NAMESPACE
 }
 
 get_logs backend > "$LOG_DIR/backend.txt"


### PR DESCRIPTION
This PR adds a `--namespace` argument to the `create-support-bundle` script, allowing users to override the default namespace (studio). This functionality is useful in cases where Studio is deployed in a different Kubernetes namespace.