### PR TITLE
Fix broken link to AMI docs

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -4,4 +4,4 @@ This AMI contains K3s along with a preconfigured ingress-nginx reverse proxy.
 
 ## Documentation
 
-Documentation about installing AMI is available under dvc.org [docs](https://dvc.org/doc/studio/selfhosted/installation/ami).
+Documentation about installing AMI is available under dvc.org [docs](https://dvc.org/doc/studio/selfhosted/installation/aws-ami).


### PR DESCRIPTION
https://github.com/iterative/studio-selfhosted/tree/main/packer#readme links to https://dvc.org/doc/studio/selfhosted/installation/ami which is 404 .

Looks like it should be https://dvc.org/doc/studio/self-hosting/installation/aws-ami