### PR TITLE
create-support-bundle: Fix mkdir command

### DIFF
--- a/packer/create-support-bundle.sh
+++ b/packer/create-support-bundle.sh
@@ -29,7 +29,7 @@ while [ $# -ne 0 ]; do
   esac
 done
 
-mkdir "$LOG_DIR"
+mkdir -p "$LOG_DIR"
 
 get_logs() {
     POD_NAME=$(kubectl get pods --namespace $NAMESPACE -l "app.kubernetes.io/name=studio-$1,app.kubernetes.io/instance=studio" -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
I've added `-p` to mkdir so it doesn't fail in cases where `/tmp/studio-support` directory already exists

```
$ create-support-bundle                                                 
+ NAMESPACE=studio
+ LOG_DIR=/tmp/studio-support
+ '[' 0 -ne 0 ']'
+ mkdir /tmp/studio-support
mkdir: cannot create directory ‘/tmp/studio-support’: File exists
```

