### PR TITLE
Reduce number of regions where the image can be shared

### DIFF
--- a/packer/studio_ami.pkr.hcl
+++ b/packer/studio_ami.pkr.hcl
@@ -8,7 +8,7 @@ packer {
 }
 
 variables {
-  image_name             = "studio-selfhosted-{{isotime `2006-01-02`}}"
+  image_name             = "studio-selfhosted"
   image_description      = "Iterative Studio Selfhosted - {{isotime `2006-01-02`}}"
   aws_build_region       = "us-east-1"
   aws_build_instance     = "c6a.large"
@@ -88,9 +88,8 @@ source "amazon-ebs" "source" {
   source_ami   = data.amazon-ami.ubuntu.id
   ssh_username = "ubuntu"
 
-
   force_delete_snapshot = !var.skip_create_ami
-  force_deregister      = !var.skip_create_ami
+#   force_deregister      = !var.skip_create_ami
 
   tags            = local.aws_tags
   run_tags        = local.aws_tags


### PR DESCRIPTION
Unfortunately we hit the quota limit, while images are not used.

```
Build 'amazon-ebs.source' errored after 14 minutes 35 seconds: Error modify AMI attributes: ResourceLimitExceeded: You have reached your quota of 5 for the number of public images allowed in this Region. Deregister unused public images or make them private, or request an increase in your public AMIs quota.
	status code: 400, request id: 9dbc1f11-c4e4-41bc-b395-c545b84fa21b

==> Wait completed after 14 minutes 35 seconds

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs.source: Error modify AMI attributes: ResourceLimitExceeded: You have reached your quota of 5 for the number of public images allowed in this Region. Deregister unused public images or make them private, or request an increase in your public AMIs quota.
	status code: 400, request id: 9dbc1f11-c4e4-41bc-b395-c545b84fa21b

```